### PR TITLE
Tratamento Identity e tracking

### DIFF
--- a/Persistence/DitoIdentifyDataManager.swift
+++ b/Persistence/DitoIdentifyDataManager.swift
@@ -86,11 +86,29 @@ class DitoIdentifyDataManager {
         }
     }
     
+    private func clearIdentifyCache() {
+        guard let context = DitoCoreDataManager.shared.container?.viewContext else { return }
+        
+        do {
+            let fetchRequest = NSFetchRequest<Identify>(entityName: "Identify")
+            let identifyList: [Identify] = try context.fetch(fetchRequest)
+            
+            for identify in identifyList {
+                context.delete(identify)
+            }
+            try context.save()
+            DitoLogger.information("Identify Deleted - Successfully!!!")
+                    
+        } catch let fetchErr {
+            DitoLogger.error("Error to fetch Identify: \(fetchErr.localizedDescription)")
+        }
+    }
+    
     @discardableResult
     func save(id: String, reference: String?, json: String?, send: Bool) -> Bool {
         
         guard let context = DitoCoreDataManager.shared.container?.viewContext else { return false }
-        delete(id: id)
+        clearIdentifyCache()
         
         do {
             guard let identify = NSEntityDescription.insertNewObject(forEntityName: "Identify", into: context) as? Identify

--- a/Sources/Controllers/Offline/DitoTrackOffline.swift
+++ b/Sources/Controllers/Offline/DitoTrackOffline.swift
@@ -19,10 +19,24 @@ struct DitoTrackOffline {
     }
     
     func track(event: DitoEventRequest) {
+        
+        if self.identifyOffline.getSavingState {
+            self.identifyOffline.setIdentityCompletionClosure{
+                self.completeTrack(event: event)
+            }
+        } else {
+            self.completeTrack(event: event)
+        }
+    }
+    
+    func completeTrack(event: DitoEventRequest) {
+        
+        //TODO: Confirmar se há histórico de erro por conta deste nested Dispatch
         DispatchQueue.global().async {
             let json = event.toString
             self.trackDataManager.save(event: json)
         }
+
     }
     
     var reference: String? {

--- a/Sources/Controllers/Offline/DitoTrackOffline.swift
+++ b/Sources/Controllers/Offline/DitoTrackOffline.swift
@@ -31,7 +31,6 @@ struct DitoTrackOffline {
     
     func completeTrack(event: DitoEventRequest) {
         
-        //TODO: Confirmar se há histórico de erro por conta deste nested Dispatch
         DispatchQueue.global().async {
             let json = event.toString
             self.trackDataManager.save(event: json)


### PR DESCRIPTION
 - Garante o salvamento de um valor único para o Identity
 - Garante que a chamada de tracking espere o fim do Identify para executar